### PR TITLE
Fix Example.cpp for linux

### DIFF
--- a/applications/Example/Example.cpp
+++ b/applications/Example/Example.cpp
@@ -1,5 +1,5 @@
 #include "Example.h"
-#include "UI/UI.h" // Include the UI Framework
+#include "ui/UI.h" // Include the UI Framework
 
 // Run once
 void ExampleAPP::Setup() {


### PR DESCRIPTION
Fixed include in Example.cpp to allow building on Linux according to comment on [this pull request](https://github.com/203Electronics/MatrixOS/pull/32). 

This pull request is separate because I reset the history of my fork.