### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,6 @@ build/
 *.app
 log.txt
 .last_config
+
+# macOS
 .DS_Store


### PR DESCRIPTION
macOS constantly recreates .DS_Store files, which is quite annoying, so this PR adds them to .gitignore.